### PR TITLE
chore: add skaffold descriptors for gcp deployment

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:alpine
+
+ENV NODE_ENV production
+
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm install --only=prod
+
+COPY . .
+
+RUN npm run build
+
+CMD ["npm", "run", "start:prod"]

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.1'
+
+services:
+  api-mongo:
+    image: mongo
+    ports:
+      - '27017:27017'

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,8 +1,14 @@
+import { RequestMethod } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.setGlobalPrefix('api', {
+    exclude: [{ path: 'health', method: RequestMethod.GET }],
+  });
+
   await app.listen(3000);
 }
 bootstrap();

--- a/infra/k8s-dev/api-depl.yml
+++ b/infra/k8s-dev/api-depl.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: 
+  name: api-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: us.gcr.io/challenge-pl/api
+          env: 
+            - name: JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jwt-secret
+                  key: jwt_key
+            - name: DB_HOST
+              value: 'api-mongo-srv'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-srv
+spec:
+  selector:
+    app: api
+  ports:
+    - name: api
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/infra/k8s-dev/ingress-srv.yml
+++ b/infra/k8s-dev/ingress-srv.yml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-service
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+spec:
+  rules:
+    - host: challenge.pl
+      http:
+        paths:
+          - path: /api/?(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: api-srv
+                port:
+                  number: 3000
+          - path: /?(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: spa-srv
+                port:
+                  number: 3000

--- a/infra/k8s-dev/spa-depl.yml
+++ b/infra/k8s-dev/spa-depl.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: 
+  name: spa-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spa
+  template:
+    metadata:
+      labels:
+        app: spa
+    spec:
+      containers:
+        - name: spa
+          image: us.gcr.io/challenge-pl/spa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spa-srv
+spec:
+  selector:
+    app: spa
+  ports:
+    - name: spa
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/infra/k8s-prod/api-depl.yml
+++ b/infra/k8s-prod/api-depl.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: 
+  name: api-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: igordonin/api
+          env: 
+            - name: JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: jwt-secret
+                  key: jwt_key
+            - name: DB_HOST
+              value: 'api-mongo-srv'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-srv
+spec:
+  selector:
+    app: api
+  ports:
+    - name: api
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/infra/k8s-prod/ingress-srv.yml
+++ b/infra/k8s-prod/ingress-srv.yml
@@ -1,0 +1,58 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-service
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+spec:
+  rules:
+    - host: www.ticketing-app-igordonin.xyz
+      http:
+        paths:
+          - path: /api/?(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: api-srv
+                port:
+                  number: 3000
+          - path: /?(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: spa-srv
+                port:
+                  number: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: 'true'
+    service.beta.kubernetes.io/do-loadbalancer-hostname: 'www.ticketing-app-igordonin.xyz'
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller

--- a/infra/k8s-prod/spa-depl.yml
+++ b/infra/k8s-prod/spa-depl.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: 
+  name: spa-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spa
+  template:
+    metadata:
+      labels:
+        app: spa
+    spec:
+      containers:
+        - name: spa
+          image: igordonin/spa
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: spa-srv
+spec:
+  selector:
+    app: spa
+  ports:
+    - name: spa
+      protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/infra/k8s/api-mongo-depl.yml
+++ b/infra/k8s/api-mongo-depl.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-mongo-depl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-mongo
+  template:
+    metadata:
+      labels:
+        app: api-mongo
+    spec:
+      containers:
+        - name: api-mongo
+          image: mongo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-mongo-srv
+spec:
+  selector:
+    app: api-mongo
+  ports:
+    - name: db
+      protocol: TCP
+      port: 27017
+      targetPort: 27017

--- a/skaffold.yml
+++ b/skaffold.yml
@@ -1,0 +1,27 @@
+apiVersion: skaffold/v2alpha3
+kind: Config
+deploy:
+  kubectl:
+    manifests:
+      - ./infra/k8s/*
+      - ./infra/k8s-dev/*
+build:
+  googleCloudBuild:
+    projectId: challenge-pl
+  artifacts:
+    - image: us.gcr.io/challenge-pl/api
+      context: api
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: 'src/**/*.ts'
+            dest: .
+    - image: us.gcr.io/challenge-pl/spa
+      context: spa
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: '**/*.ts'
+            dest: .

--- a/spa/.dockerignore
+++ b/spa/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/spa/Dockerfile
+++ b/spa/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:alpine
+
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+
+CMD  ["npm", "run", "start"]


### PR DESCRIPTION
- Add api to the base path of every backend to split backend and frontend routes
- Create Dockerfiles for both projects
- Create deployment for MongoDB
- Create deployment for ingress-ngnix

Closes #25 